### PR TITLE
Add vitest setup and BlogCard test

### DIFF
--- a/my-react-app/package.json
+++ b/my-react-app/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -32,6 +33,8 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0",
-    "vite-plugin-sitemap": "^0.7.1"
+    "vite-plugin-sitemap": "^0.7.1",
+    "@testing-library/react": "^14.2.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/my-react-app/src/components/BlogCard.test.tsx
+++ b/my-react-app/src/components/BlogCard.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Router } from 'react-router-dom'
+import { createMemoryHistory } from 'history'
+import { BlogCard } from './BlogCard'
+
+test('navigates to the blog post when clicked', async () => {
+  const history = createMemoryHistory()
+  render(
+    <Router location={history.location} navigator={history}>
+      <ul>
+        <BlogCard slug="001" title="Test Post" date="2024-01-01" cover="/img.jpg" />
+      </ul>
+    </Router>
+  )
+
+  await userEvent.click(screen.getByRole('link', { name: /test post/i }))
+  expect(history.location.pathname).toBe('/blog/001')
+})

--- a/my-react-app/vite.config.ts
+++ b/my-react-app/vite.config.ts
@@ -22,5 +22,8 @@ export default defineConfig({
       // （任意）生成から除外したいパス
       // exclude: ['/secret-page']
     })
-  ]
+  ],
+  test: {
+    environment: 'jsdom'
+  }
 })


### PR DESCRIPTION
## Summary
- add test script and dependencies for Vitest
- configure jsdom test environment
- add basic BlogCard click navigation test

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841459a86d483299420ce0671dea808