### PR TITLE
Use env variable for contact form URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # HP
 ブログだったりポートフォリオだったりする予定
+
+## Contact Form Setup
+
+The Google Form URL used on the contact page is configured through an
+environment variable. Create a `.env` file inside `my-react-app` with the
+following entry:
+
+```bash
+VITE_CONTACT_FORM_URL="https://docs.google.com/forms/d/e/YOUR_FORM_ID/formResponse"
+```
+
+Replace the URL with your actual form URL. Vite exposes environment variables
+prefixed with `VITE_` to the client application during build.

--- a/my-react-app/src/mainhomes/contact.tsx
+++ b/my-react-app/src/mainhomes/contact.tsx
@@ -2,7 +2,8 @@
 import React, { useState } from "react";
 
 const GOOGLE_FORM_ACTION =
-  "https://docs.google.com/forms/d/e/YOUR_FORM_ID/formResponse";  // ★YOUR_FORM_IDを置き換えてください
+  import.meta.env.VITE_CONTACT_FORM_URL ??
+  "https://docs.google.com/forms/d/e/YOUR_FORM_ID/formResponse";
 
 const Contact: React.FC = () => {
   const [sending, setSending] = useState(false);


### PR DESCRIPTION
## Summary
- load contact form URL from `VITE_CONTACT_FORM_URL`
- describe how to configure this value in README

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm run lint --silent` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684149ba59c883298c9093b8c89175a3