### PR TITLE
Improve typing for dynamic blog imports

### DIFF
--- a/my-react-app/src/blog/BlogPost.tsx
+++ b/my-react-app/src/blog/BlogPost.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState, Suspense } from "react";
 import { useParams } from "react-router-dom";
 
-const modules = import.meta.glob("./contents/*.tsx");
+interface BlogPostModule {
+  default: React.FC;
+}
+const modules: Record<string, () => Promise<BlogPostModule>> = import.meta.glob("./contents/*.tsx");
 
 const NotFound: React.FC = () => <div>Not Found</div>;
 
@@ -13,7 +16,7 @@ const BlogPost: React.FC = () => {
     if (!slug) return;
     const importer = modules[`./contents/${slug}.tsx`];
     if (importer) {
-      importer().then((mod: any) => {
+      importer().then((mod: BlogPostModule) => {
         setComponent(() => mod.default);
       });
     } else {


### PR DESCRIPTION
## Summary
- add an interface for dynamically imported blog content
- use that interface when setting the component

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684149bbf8508329b3cbb368516b3582