### PR TITLE
Add NotFound component and routing

### DIFF
--- a/my-react-app/src/App.tsx
+++ b/my-react-app/src/App.tsx
@@ -8,6 +8,7 @@ import Contact from "./mainhomes/contact";
 import Portfolio from "./mainhomes/portfolio";
 import About from "./mainhomes/about";
 import BlogPost from "./blog/BlogPost";
+import NotFound from "./mainhomes/NotFound";
 
 const App: React.FC = () => {
   return (
@@ -20,6 +21,7 @@ const App: React.FC = () => {
         <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/portfolio" element={<Portfolio />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />
     </Router>

--- a/my-react-app/src/mainhomes/NotFound.tsx
+++ b/my-react-app/src/mainhomes/NotFound.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const NotFound: React.FC = () => (
+  <div style={styles.container}>
+    <h1 style={styles.title}>ページが見つかりません</h1>
+    <Link to="/" style={styles.link}>
+      ホームへ戻る
+    </Link>
+  </div>
+);
+
+const styles: { [key: string]: React.CSSProperties } = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "80vh",
+    textAlign: "center",
+    gap: "1rem",
+  },
+  title: {
+    fontSize: "2rem",
+  },
+  link: {
+    color: "#1976d2",
+    textDecoration: "none",
+    fontWeight: "bold",
+  },
+};
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- add a simple NotFound page with a link back home
- register the NotFound page for all unmatched routes

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684149bd82e88329ae165176b7893e28