### PR TITLE
Add tests for PortfolioCard and 404 routing

### DIFF
--- a/my-react-app/src/App.tsx
+++ b/my-react-app/src/App.tsx
@@ -8,6 +8,7 @@ import Contact from "./mainhomes/contact";
 import Portfolio from "./mainhomes/portfolio";
 import About from "./mainhomes/about";
 import BlogPost from "./blog/BlogPost";
+import NotFound from "./mainhomes/notfound";
 
 const App: React.FC = () => {
   return (
@@ -20,6 +21,7 @@ const App: React.FC = () => {
         <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/portfolio" element={<Portfolio />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />
     </Router>

--- a/my-react-app/src/AppRouting.test.tsx
+++ b/my-react-app/src/AppRouting.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react'
+import App from './App'
+
+test('unknown path shows 404 page', () => {
+  window.history.pushState({}, '', '/does-not-exist')
+  render(<App />)
+  expect(screen.getByText(/404 Not Found/i)).toBeInTheDocument()
+})

--- a/my-react-app/src/components/PortfolioCard.test.tsx
+++ b/my-react-app/src/components/PortfolioCard.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { PortfolioCard } from './PortfolioCard'
+
+test('renders portfolio card data', () => {
+  render(
+    <PortfolioCard
+      img="/img.jpg"
+      title="Project Title"
+      description="Project description"
+      tags={['React', 'TypeScript']}
+      date="2024-06-01"
+    />
+  )
+
+  expect(screen.getByRole('img', { name: /project title/i })).toBeInTheDocument()
+  expect(screen.getByText('Project Title')).toBeInTheDocument()
+  expect(screen.getByText('Project description')).toBeInTheDocument()
+  expect(screen.getByText('React')).toBeInTheDocument()
+  expect(screen.getByText('TypeScript')).toBeInTheDocument()
+  expect(screen.getByText('2024-06-01')).toBeInTheDocument()
+})

--- a/my-react-app/src/mainhomes/notfound.tsx
+++ b/my-react-app/src/mainhomes/notfound.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const NotFound: React.FC = () => <div>404 Not Found</div>
+
+export default NotFound


### PR DESCRIPTION
## Summary
- add `NotFound` page and catch-all route
- add unit tests for `PortfolioCard`
- test rendering of 404 page when navigating to an unknown route

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684149bfec408329b2d9dad5b0cd79b5