### PR TITLE
Fix header width to stop nav shifting

### DIFF
--- a/my-react-app/src/components/header.tsx
+++ b/my-react-app/src/components/header.tsx
@@ -15,7 +15,7 @@ const Header: React.FC = () => {
           position: "fixed",
           top: 0,
           left: 0,
-          width: "100vw",
+          width: "100%",
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",

--- a/my-react-app/src/mainhomes/about.tsx
+++ b/my-react-app/src/mainhomes/about.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 
 // 共通スタイルオブジェクト
 const sectionStyle = {
-  width: '100vw',
+  width: '100%',
   minHeight: '100vh',
   display: 'flex',
   alignItems: 'center',

--- a/my-react-app/src/mainhomes/home.tsx
+++ b/my-react-app/src/mainhomes/home.tsx
@@ -41,7 +41,7 @@ const styles: { [key: string]: React.CSSProperties } = {
   container: {
     backgroundColor: "#009688",
     height: "100vh",
-    width: "100vw",
+    width: "100%",
     display: "flex",
     justifyContent: "center",
     alignItems: "center",


### PR DESCRIPTION
## Summary
- keep layout consistent by using `width: 100%` rather than `100vw`
- apply same fix to Home and About sections

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68414c9bc8288329a6ee299d683820b9