### PR TITLE
Update about page and career timeline

### DIFF
--- a/my-react-app/src/mainhomes/about.tsx
+++ b/my-react-app/src/mainhomes/about.tsx
@@ -125,7 +125,7 @@ const About: React.FC = () => {
       {/* Section 1: 何者なのか */}
       <Section id="about" title="なにもの？" backgroundColor="#3949ab">
         <Typography variant="body1" sx={{ fontSize: { xs: '0.9rem', sm: '1rem' } }}>
-          情報系学部の3年生です。Web,アプリ,ゲームなど作ったりしています。
+          俺は今年4年生です。Web,アプリ,ゲームなど作ったりしています。
         </Typography>
         <Typography variant="body1" sx={{ fontSize: { xs: '0.9rem', sm: '1rem' } }}>
           登山、キャンプ、旅行もそこそこ好きです。
@@ -153,6 +153,7 @@ const About: React.FC = () => {
         <TimelineItem year="2022" description="smolt" />
         <TimelineItem year="2023" description="ラウンドワン" />
         <TimelineItem year="2024" description="wowd" />
+        <TimelineItem year="2025" description="バプロbar" />
       </Section>
     </>
   );


### PR DESCRIPTION
## Summary
- update about text to say "俺は今年4年生です" instead of previous wording
- change career entry for 2025 to say "バプロbar"

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842429c50a083298b63f4f70f9993c9