### PR TITLE
Add portfolio post pages

### DIFF
--- a/my-react-app/public/portfoliocover/cover.json
+++ b/my-react-app/public/portfoliocover/cover.json
@@ -1,5 +1,6 @@
 [
     {
+      "slug": "001",
       "img": "/portfoliocover/img/00.png",
       "title": "Portfolio Title 1",
       "description": "This is a description of the first project.",
@@ -7,6 +8,7 @@
       "date": "2025-04-25"
     },
     {
+      "slug": "002",
       "img": "/portfoliocover/img/01.png",
       "title": "Portfolio Title 2",
       "description": "This is a description of the second project.",
@@ -14,6 +16,7 @@
       "date": "2025-04-24"
     },
     {
+      "slug": "003",
       "img": "/portfoliocover/img/02.png",
       "title": "Portfolio Title 3",
       "description": "This is a description of the third project.",
@@ -21,6 +24,7 @@
       "date": "2025-04-23"
     },
     {
+      "slug": "004",
       "img": "/portfoliocover/img/03.png",
       "title": "Portfolio Title 4",
       "description": "This is a description of the fourth project.",
@@ -28,6 +32,7 @@
       "date": "2025-04-22"
     },
     {
+      "slug": "005",
       "img": "/portfoliocover/img/04.png",
       "title": "Portfolio Title 5",
       "description": "This is a description of the fifth project.",
@@ -35,6 +40,7 @@
       "date": "2025-04-21"
     },
     {
+      "slug": "006",
       "img": "/portfoliocover/img/05.png",
       "title": "Portfolio Title 6",
       "description": "This is a description of the sixth project.",
@@ -42,6 +48,7 @@
       "date": "2025-04-20"
     },
     {
+      "slug": "007",
       "img": "/portfoliocover/img/06.png",
       "title": "Portfolio Title 7",
       "description": "This is a description of the seventh project.",
@@ -49,6 +56,7 @@
       "date": "2025-04-19"
     },
     {
+      "slug": "008",
       "img": "/portfoliocover/img/07.png",
       "title": "Portfolio Title 8",
       "description": "This is a description of the eighth project.",
@@ -56,6 +64,7 @@
       "date": "2025-04-18"
     },
     {
+      "slug": "009",
       "img": "/portfoliocover/img/08.png",
       "title": "Portfolio Title 9",
       "description": "This is a description of the ninth project.",
@@ -63,6 +72,7 @@
       "date": "2025-04-17"
     },
     {
+      "slug": "010",
       "img": "/portfoliocover/img/09.png",
       "title": "Portfolio Title 10",
       "description": "This is a description of the tenth project.",

--- a/my-react-app/src/App.tsx
+++ b/my-react-app/src/App.tsx
@@ -8,6 +8,7 @@ import Contact from "./mainhomes/contact";
 import Portfolio from "./mainhomes/portfolio";
 import About from "./mainhomes/about";
 import BlogPost from "./blog/BlogPost";
+import PortfolioPost from "./portfolio/PortfolioPost";
 import NotFound from "./mainhomes/NotFound";
 
 const App: React.FC = () => {
@@ -21,6 +22,7 @@ const App: React.FC = () => {
         <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/portfolio" element={<Portfolio />} />
+        <Route path="/portfolio/:slug" element={<PortfolioPost />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />

--- a/my-react-app/src/components/PortfolioCard.test.tsx
+++ b/my-react-app/src/components/PortfolioCard.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Router } from 'react-router-dom'
+import { createMemoryHistory } from 'history'
+import { PortfolioCard } from './PortfolioCard'
+
+test('navigates to the portfolio post when clicked', async () => {
+  const history = createMemoryHistory()
+  render(
+    <Router location={history.location} navigator={history}>
+      <ul>
+        <PortfolioCard
+          slug="001"
+          img="/img.jpg"
+          title="Project"
+          description="desc"
+          tags={[]}
+          date="2024-01-01"
+        />
+      </ul>
+    </Router>
+  )
+
+  await userEvent.click(screen.getByRole('link', { name: /project/i }))
+  expect(history.location.pathname).toBe('/portfolio/001')
+})

--- a/my-react-app/src/components/PortfolioCard.tsx
+++ b/my-react-app/src/components/PortfolioCard.tsx
@@ -1,7 +1,9 @@
 // src/components/PortfolioCard.tsx
 import React from "react";
+import { Link } from "react-router-dom";
 
 type PortfolioProps = {
+  slug: string;
   img: string;
   title: string;
   description: string;
@@ -10,6 +12,7 @@ type PortfolioProps = {
 };
 
 export const PortfolioCard: React.FC<PortfolioProps> = ({
+  slug,
   img,
   title,
   description,
@@ -17,20 +20,22 @@ export const PortfolioCard: React.FC<PortfolioProps> = ({
   date,
 }) => {
   return (
-    <div style={{ border: "1px solid #333", width: 300 }}>
-      <div style={{ height: 150, backgroundColor: "#17647c" }}>
-        <img src={img} alt={title} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-      </div>
-      <div style={{ backgroundColor: "#eee", padding: "10px" }}>
-        <h3>{title}</h3>
-        <p>{description}</p>
-        <div style={{ margin: "10px 0" }}>
-          {tags.map((tag, i) => (
-            <span key={i} style={{ marginRight: 8 }}>{tag}</span>
-          ))}
+    <Link to={`/portfolio/${slug}`} style={{ textDecoration: "none", color: "inherit" }}>
+      <div style={{ border: "1px solid #333", width: 300 }}>
+        <div style={{ height: 150, backgroundColor: "#17647c" }}>
+          <img src={img} alt={title} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
         </div>
-        <small>{date}</small>
+        <div style={{ backgroundColor: "#eee", padding: "10px" }}>
+          <h3>{title}</h3>
+          <p>{description}</p>
+          <div style={{ margin: "10px 0" }}>
+            {tags.map((tag, i) => (
+              <span key={i} style={{ marginRight: 8 }}>{tag}</span>
+            ))}
+          </div>
+          <small>{date}</small>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 };

--- a/my-react-app/src/mainhomes/portfolio.tsx
+++ b/my-react-app/src/mainhomes/portfolio.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { PortfolioCard } from "../components/PortfolioCard";
 
 type PortfolioData = {
+  slug: string;
   img: string;
   title: string;
   description: string;
@@ -30,8 +31,8 @@ const Portfolio: React.FC = () => {
           justifyContent: "center", // ← ここで中央寄せ
         }}
       >
-        {data.map((item, i) => (
-          <PortfolioCard key={i} {...item} />
+        {data.map((item) => (
+          <PortfolioCard key={item.slug} {...item} />
         ))}
       </div>
     </div>

--- a/my-react-app/src/portfolio/PortfolioPost.tsx
+++ b/my-react-app/src/portfolio/PortfolioPost.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState, Suspense } from "react";
+import { useParams } from "react-router-dom";
+
+interface PortfolioModule {
+  default: React.FC;
+}
+
+const modules: Record<string, () => Promise<PortfolioModule>> = import.meta.glob(
+  "./contents/*.tsx"
+);
+
+const NotFound: React.FC = () => <div>Not Found</div>;
+
+const PortfolioPost: React.FC = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const [Component, setComponent] = useState<React.FC | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    const importer = modules[`./contents/${slug}.tsx`];
+    if (importer) {
+      importer().then((mod: PortfolioModule) => {
+        setComponent(() => mod.default);
+      });
+    } else {
+      setComponent(() => NotFound);
+    }
+  }, [slug]);
+
+  if (!Component) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Component />
+    </Suspense>
+  );
+};
+
+export default PortfolioPost;

--- a/my-react-app/src/portfolio/contents/001.tsx
+++ b/my-react-app/src/portfolio/contents/001.tsx
@@ -1,0 +1,13 @@
+export const meta = {
+  title: "First Portfolio Item",
+  date: "2025-04-25",
+};
+
+export default function Portfolio001() {
+  return (
+    <article>
+      <h1>{meta.title}</h1>
+      <p>Details about the project go here.</p>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- make portfolio cards link to new post pages
- support slug in `cover.json`
- add `PortfolioPost` component and sample post
- add test for new card component
- route `/portfolio/:slug` to dynamic posts

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68424717bec08329ab4ba195aa007e1a