### PR TITLE
Unify portfolio card style

### DIFF
--- a/my-react-app/src/components/PortfolioCard.test.tsx
+++ b/my-react-app/src/components/PortfolioCard.test.tsx
@@ -14,8 +14,6 @@ test('navigates to the portfolio post when clicked', async () => {
           slug="001"
           img="/img.jpg"
           title="Project"
-          description="desc"
-          tags={[]}
           date="2024-01-01"
         />
       </ul>

--- a/my-react-app/src/components/PortfolioCard.tsx
+++ b/my-react-app/src/components/PortfolioCard.tsx
@@ -15,8 +15,6 @@ type PortfolioProps = {
   slug: string;
   img: string;
   title: string;
-  description: string;
-  tags: string[];
   date: string;
 };
 
@@ -31,8 +29,6 @@ export const PortfolioCard: React.FC<PortfolioProps> = ({
   slug,
   img,
   title,
-  description,
-  tags,
   date,
 }) => {
   return (
@@ -44,15 +40,7 @@ export const PortfolioCard: React.FC<PortfolioProps> = ({
             <Typography gutterBottom variant="h6" component="div" color="text.primary">
               {title}
             </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {description}
-            </Typography>
-            <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
-              {tags.map((tag, i) => (
-                <Chip key={i} label={tag} size="small" />
-              ))}
-            </Stack>
-            <Typography variant="caption" color="text.secondary">
+            <Typography variant="body2" color="text.secondary">
               {date}
             </Typography>
           </CardContent>

--- a/my-react-app/src/mainhomes/portfolio.tsx
+++ b/my-react-app/src/mainhomes/portfolio.tsx
@@ -30,7 +30,7 @@ const Portfolio: React.FC = () => {
         <Grid container spacing={4} component="ul" sx={{ p: 0, listStyle: "none" }}>
           {data.map((item) => (
             <Grid item key={item.slug} xs={12} sm={6} md={4} component="li" sx={{ listStyle: "none" }}>
-              <PortfolioCard {...item} />
+              <PortfolioCard slug={item.slug} img={item.img} title={item.title} date={item.date} />
             </Grid>
           ))}
         </Grid>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    // Viteのconfigを明示している場合はこちら（my-react-app/vite.config.tsがあるなら）
     "dev": "vite --config my-react-app/vite.config.ts",
     "build": "vite build --config my-react-app/vite.config.ts",
     "preview": "vite preview --config my-react-app/vite.config.ts",


### PR DESCRIPTION
## Summary
- align portfolio listing cards with blog card layout
- remove description and tag display from `PortfolioCard`
- adjust portfolio list and tests accordingly
- fix `package.json` by removing comment to allow npm scripts

## Testing
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68621ecbacb08329806b7355a14e83d0